### PR TITLE
OB-32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ $(GORELEASER):
 	go install github.com/goreleaser/goreleaser@v1.9.2
 
 build: $(GORELEASER)
-	$(GORELEASER) build --skip-validate --rm-dist
+	$(GORELEASER) build --skip validate --rm-dist
 
 release-snapshot: $(GORELEASER)
 	$(GORELEASER) release --snapshot --skip-publish --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ $(GORELEASER):
 	go install github.com/goreleaser/goreleaser@v1.9.2
 
 build: $(GORELEASER)
-	$(GORELEASER) build --skip validate --rm-dist
+	$(GORELEASER) build --skip-validate --rm-dist --snapshot
 
 release-snapshot: $(GORELEASER)
 	$(GORELEASER) release --snapshot --skip-publish --rm-dist

--- a/src/checkers/periodicSecretChecker.go
+++ b/src/checkers/periodicSecretChecker.go
@@ -162,7 +162,7 @@ func (p *PeriodicSecretChecker) StartChecking() {
 
 				if include && !exclude {
 					glog.Infof("Publishing %v/%v metrics %v", secret.Name, secret.Namespace, name)
-					err = p.exporter.ExportMetrics(bytes, name, secret.Name, secret.Namespace)
+					err = p.exporter.ExportMetrics(bytes, name, secret.Name, secret.Namespace, secret.GetLabels())
 					if err != nil {
 						glog.Errorf("Error exporting secret %v", err)
 						metrics.ErrorTotal.Inc()

--- a/src/exporters/secretExporter.go
+++ b/src/exporters/secretExporter.go
@@ -9,15 +9,17 @@ type SecretExporter struct {
 }
 
 // ExportMetrics exports the provided PEM file
-func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secretNamespace string) error {
+func (c *SecretExporter) ExportMetrics(bytes []byte, keyName, secretName, secretNamespace string, labels map[string]string) error {
 	metricCollection, err := secondsToExpiryFromCertAsBytes(bytes)
 	if err != nil {
 		return err
 	}
 
+	serviceline := labels["serviceline"]
+
 	for _, metric := range metricCollection {
-		metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.durationUntilExpiry)
-		metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace).Set(metric.notAfter)
+		metrics.SecretExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace, serviceline).Set(metric.durationUntilExpiry)
+		metrics.SecretNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, secretName, secretNamespace, serviceline).Set(metric.notAfter)
 	}
 
 	return nil

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -63,7 +63,7 @@ var (
 			Name:      "secret_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the secret expires.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace", "serviceline"},
 	)
 
 	// SecretNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -73,7 +73,7 @@ var (
 			Name:      "secret_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the secret.",
 		},
-		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace"},
+		[]string{"key_name", "issuer", "cn", "secret_name", "secret_namespace", "serviceline"},
 	)
 
 	// AwsCertExpirySeconds is a prometheus gauge that indicates the number of seconds until certificates on AWS expires.

--- a/test/cert-manager/certs.yaml
+++ b/test/cert-manager/certs.yaml
@@ -31,6 +31,8 @@ metadata:
   name: test
   annotations:
     test: test
+  labels:
+    serviceline: test
 type: Opaque
 ---
 apiVersion: v1
@@ -85,4 +87,3 @@ webhooks:
         apiGroups: ["core", ""]
         apiVersions: ["*"]
         resources: ["persistentvolumeclaims"]
-

--- a/test/cert-manager/test.sh
+++ b/test/cert-manager/test.sh
@@ -65,7 +65,7 @@ pid=$!
 sleep 10
 
 validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="example.com",issuer="example.com",key_name="ca.crt",secret_name="selfsigned-cert-tls",secret_namespace="cert-manager-test"}' 100
-validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="hms-test",issuer="hms-test",key_name="test.crt",secret_name="test",secret_namespace="default"}'
+validateMetrics 'cert_exporter_secret_expires_in_seconds{cn="hms-test",issuer="hms-test",key_name="test.crt",secret_name="test",secret_namespace="default", serviceline="test"}'
 
 # kill exporter
 echo "** Killing $pid"


### PR DESCRIPTION
Add serviceline label to secret metrics -- assumes each secret is labeled with a serviceline (if it is not, the program will continue without the label)