### PR TITLE
PRD-149 Pull image from teledev repo

### DIFF
--- a/helm/cert-exporter/Chart.yaml
+++ b/helm/cert-exporter/Chart.yaml
@@ -4,4 +4,4 @@ description: Monitors and exposes PKI information as Prometheus metrics
 
 type: application
 version: 3.4.1
-appVersion: v2.11.1
+appVersion: latest

--- a/helm/cert-exporter/values.yaml
+++ b/helm/cert-exporter/values.yaml
@@ -8,7 +8,7 @@ certManager:
   # label2: test
 
   image:
-    repository: joeelliott/cert-exporter
+    repository: docker.teledev.io/cert-exporter
     # The default tag is ".Chart.AppVersion", only set "tag" to override that
     tag: 
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Use `docker.teledev.io/cert-exporter` and `latest` version in helm chart to pull p12 enabled cert-exporter image.