### PR TITLE
PRD-2223 export serviceline label for configmaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   test:
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: |

--- a/.semversioner/next-release/patch-20250827193117.json
+++ b/.semversioner/next-release/patch-20250827193117.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "export serviceline label for configmaps"
+}

--- a/src/checkers/periodicConfigMapChecker.go
+++ b/src/checkers/periodicConfigMapChecker.go
@@ -170,7 +170,7 @@ func (p *PeriodicConfigMapChecker) StartChecking() {
 						}
 					}
 
-					err = p.exporter.ExportMetrics(data, name, configMap.Name, configMap.Namespace, password)
+					err = p.exporter.ExportMetrics(data, name, configMap.Name, configMap.Namespace, password, configMap.GetLabels())
 					if err != nil {
 						glog.Errorf("Error exporting configMap %v", err)
 						metrics.ErrorTotal.Inc()

--- a/src/exporters/configMapExporter.go
+++ b/src/exporters/configMapExporter.go
@@ -9,15 +9,17 @@ type ConfigMapExporter struct {
 }
 
 // ExportMetrics exports the provided PEM file
-func (c *ConfigMapExporter) ExportMetrics(bytes []byte, keyName, configMapName, configMapNamespace string, password string) error {
+func (c *ConfigMapExporter) ExportMetrics(bytes []byte, keyName, configMapName, configMapNamespace, password string, labels map[string]string) error {
 	metricCollection, err := secondsToExpiryFromCertAsBytes(bytes, password)
 	if err != nil {
 		return err
 	}
 
+	serviceline := labels["serviceline"]
+
 	for _, metric := range metricCollection {
-		metrics.ConfigMapExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.durationUntilExpiry)
-		metrics.ConfigMapNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace).Set(metric.notAfter)
+		metrics.ConfigMapExpirySeconds.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace, serviceline).Set(metric.durationUntilExpiry)
+		metrics.ConfigMapNotAfterTimestamp.WithLabelValues(keyName, metric.issuer, metric.cn, configMapName, configMapNamespace, serviceline).Set(metric.notAfter)
 	}
 
 	return nil

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -93,7 +93,7 @@ var (
 			Name:      "configmap_expires_in_seconds",
 			Help:      "Number of seconds til the cert in the configmap expires.",
 		},
-		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace", "serviceline"},
 	)
 
 	// ConfigMapNotAfterTimestamp is a prometheus gauge that indicates the NotAfter timestamp.
@@ -103,7 +103,7 @@ var (
 			Name:      "configmap_not_after_timestamp",
 			Help:      "Expiration timestamp for cert in the configmap.",
 		},
-		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace"},
+		[]string{"key_name", "issuer", "cn", "configmap_name", "configmap_namespace", "serviceline"},
 	)
 
 	// WebhookExpirySeconds is a prometheus gauge that indicates the number of seconds until a kubernetes webhook certificate expires

--- a/test/cert-manager/certs.yaml
+++ b/test/cert-manager/certs.yaml
@@ -62,6 +62,8 @@ metadata:
   name: test
   annotations:
     test: test
+  labels:
+    serviceline: test
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -83,7 +85,7 @@ webhooks:
     failurePolicy: Ignore
     sideEffects: None
     rules:
-      - operations: [ "CREATE" ]
+      - operations: ["CREATE"]
         apiGroups: ["core", ""]
         apiVersions: ["*"]
         resources: ["persistentvolumeclaims"]

--- a/test/cert-manager/test.sh
+++ b/test/cert-manager/test.sh
@@ -115,7 +115,7 @@ $CERT_EXPORTER_PATH \
 pid=$!
 sleep 10
 
-validateMetrics 'cert_exporter_configmap_expires_in_seconds{cn="hms-test",configmap_name="test",configmap_namespace="default",issuer="hms-test",key_name="test.crt"}'
+validateMetrics 'cert_exporter_configmap_expires_in_seconds{cn="hms-test",configmap_name="test",configmap_namespace="default",issuer="hms-test",key_name="test.crt",serviceline="test"}'
 
 # kill exporter
 echo "** Killing $pid"


### PR DESCRIPTION
When we first deployed cert-exporter we added logic to export the serviceline label from Secrets. This PR mimics the same changes but for ConfigMaps. This is necessary because some of our ECS services are using JIT configmaps.