### PR TITLE
PRD-2223 update semversioner binary to 0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Bump Version
         run: |
-          pip install semversioner==0.6.16
+          pip install semversioner==0.9.0
           export PATH="$HOME/.local/bin:$PATH"
           ./ci-scripts/bump-version.sh
 
@@ -50,11 +50,11 @@ jobs:
           registry: docker.teledev.io
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-      
+
       - name: Push Images
         run: |
           ./ci-scripts/release.sh
-      
+
       - name: Push changes
         if: "contains(github.ref, 'master')"
         uses: ad-m/github-push-action@master

--- a/.semversioner/next-release/patch-20250903193039.json
+++ b/.semversioner/next-release/patch-20250903193039.json
@@ -1,0 +1,4 @@
+{
+  "type": "patch",
+  "description": "fix semversioner by updating binary version to 0.9.0"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as build
+FROM golang:1.18 AS build
 WORKDIR /src
 
 COPY . .


### PR DESCRIPTION
Not sure why but semversioner in this repo's pipeline was running on v0.6.16. The semversioner in our Bitbucket versioner pipe is on v0.9.0.

It hasn't been working in this repo because the `.semversioner` syntax was introduced on v0.9.0: https://github.com/raulgomis/semversioner/blob/0.9.0/CHANGELOG.md

Also fixing a warning about inconsistent capitalization.